### PR TITLE
ignore ruby stuff and add new client sub pool avail to stats

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.ruby-*
 /.bundle/
 /.yardoc
 /Gemfile.lock

--- a/lib/harness/protobuf/nats.rb
+++ b/lib/harness/protobuf/nats.rb
@@ -37,3 +37,7 @@ end
   event = ::ActiveSupport::Notifications::Event.new(*args)
   ::Harness.timing "protobuf-nats.client.request_duration", event.duration
 end
+
+::ActiveSupport::Notifications.subscribe "client.subscription_pool_available_size.protobuf-nats" do |_, _, _, _, available_size|
+  ::Harness.count "protobuf-nats.client.subscription_pool_available_size", available_size
+end

--- a/spec/harness/protobuf/nats_spec.rb
+++ b/spec/harness/protobuf/nats_spec.rb
@@ -40,6 +40,11 @@ describe ::Harness::Protobuf::Nats do
   end
 
   describe "client metrics" do
+    it "can instrument client.subscription_pool_available_size.protobuf-nats" do
+      expect(collector).to receive(:count).with("protobuf-nats.client.subscription_pool_available_size", 12)
+      ::ActiveSupport::Notifications.instrument "client.subscription_pool_available_size.protobuf-nats", 12
+    end
+
     it "can instrument client.request_timeout.protobuf-nats" do
       expect(collector).to receive(:increment).with("protobuf-nats.client.request_timeout")
       ::ActiveSupport::Notifications.instrument "client.request_timeout.protobuf-nats"


### PR DESCRIPTION
updating to get the new metrics from protobuf-nats so we can monitor the subscription pool size

@film42 